### PR TITLE
force python version to 3.7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7 AS base
+FROM python:3.7.4 AS base
 
 WORKDIR /work/
 


### PR DESCRIPTION
@pcorpet There is a problem with the online version of the app: when "Rate of OHCA at home, which only have one witness alone" is set to 0 the simulation won't update (silent fail: it displays the results for the previous set of parameters). I cannot reproduce the error with my localhost, so I guess it is an issue due to a different Python version. I'd really appreciate your opinion on this before pushing to master: do you think it could resolve the problem? 